### PR TITLE
Add support for errors + new tracer

### DIFF
--- a/google/tracer.go
+++ b/google/tracer.go
@@ -42,8 +42,12 @@ func (s span) SetLabel(k, v string) {
 	s.parent.SetLabel(k, v)
 }
 
-func (s span) SetError(k string, err error) {
-	s.parent.SetLabel(k, err.Error())
+func (s span) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	s.parent.SetLabel("err", err.Error())
 }
 
 func (s span) Finish() {

--- a/google/tracer.go
+++ b/google/tracer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/luna-duclos/instrumentedsql"
 )
 
-type tracer struct{
+type tracer struct {
 	traceOrphans bool
 }
 
@@ -40,6 +40,10 @@ func (s span) NewChild(name string) instrumentedsql.Span {
 
 func (s span) SetLabel(k, v string) {
 	s.parent.SetLabel(k, v)
+}
+
+func (s span) SetError(k string, err error) {
+	s.parent.SetLabel(k, err.Error())
 }
 
 func (s span) Finish() {

--- a/opencensus/opencensus.go
+++ b/opencensus/opencensus.go
@@ -8,7 +8,7 @@ import (
 	"github.com/luna-duclos/instrumentedsql"
 )
 
-type tracer struct{
+type tracer struct {
 	traceOrphans bool
 }
 
@@ -40,6 +40,10 @@ func (s span) NewChild(name string) instrumentedsql.Span {
 
 func (s span) SetLabel(k, v string) {
 	s.parent.SetAttributes(trace.StringAttribute{Key: k, Value: v})
+}
+
+func (s span) SetError(k string, err error) {
+	s.parent.SetAttributes(trace.StringAttribute{Key: k, Value: err.Error()})
 }
 
 func (s span) Finish() {

--- a/opencensus/opencensus.go
+++ b/opencensus/opencensus.go
@@ -42,8 +42,12 @@ func (s span) SetLabel(k, v string) {
 	s.parent.SetAttributes(trace.StringAttribute{Key: k, Value: v})
 }
 
-func (s span) SetError(k string, err error) {
-	s.parent.SetAttributes(trace.StringAttribute{Key: k, Value: err.Error()})
+func (s span) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	s.parent.SetAttributes(trace.StringAttribute{Key: "err", Value: err.Error()})
 }
 
 func (s span) Finish() {

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -49,11 +49,16 @@ func (s span) SetLabel(k, v string) {
 	s.parent.SetTag(k, v)
 }
 
-func (s span) SetError(k string, err error) {
+func (s span) SetError(err error) {
+	if err == nil {
+		return
+	}
+
 	if s.parent == nil {
 		return
 	}
-	s.parent.SetTag(k, err.Error())
+
+	s.parent.SetTag("err", err.Error())
 }
 
 func (s span) Finish() {

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/luna-duclos/instrumentedsql"
 )
 
-type tracer struct{
+type tracer struct {
 	traceOrphans bool
 }
 
@@ -34,9 +34,9 @@ func (s span) NewChild(name string) instrumentedsql.Span {
 	if s.parent == nil {
 		if s.traceOrphans {
 			return span{parent: opentracing.StartSpan(name), tracer: s.tracer}
-		} else {
-			return s
 		}
+
+		return s
 	}
 
 	return span{parent: opentracing.StartSpan(name, opentracing.ChildOf(s.parent.Context())), tracer: s.tracer}
@@ -47,6 +47,13 @@ func (s span) SetLabel(k, v string) {
 		return
 	}
 	s.parent.SetTag(k, v)
+}
+
+func (s span) SetError(k string, err error) {
+	if s.parent == nil {
+		return
+	}
+	s.parent.SetTag(k, err.Error())
 }
 
 func (s span) Finish() {

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -2,6 +2,7 @@ package opentracing
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -19,6 +20,7 @@ func TestSpanWithParent(t *testing.T) {
 
 	child := span.NewChild("child")
 	child.SetLabel("child_key", "child_value")
+	child.SetError("error", fmt.Errorf("my error"))
 	child.Finish()
 
 	span.Finish()
@@ -32,6 +34,7 @@ func TestSpanWithoutParent(t *testing.T) {
 
 	child := span.NewChild("child")
 	child.SetLabel("child_key", "child_value")
+	child.SetError("error", fmt.Errorf("my error"))
 	child.Finish()
 
 	span.Finish()

--- a/opentracing/tracer_test.go
+++ b/opentracing/tracer_test.go
@@ -20,7 +20,7 @@ func TestSpanWithParent(t *testing.T) {
 
 	child := span.NewChild("child")
 	child.SetLabel("child_key", "child_value")
-	child.SetError("error", fmt.Errorf("my error"))
+	child.SetError(fmt.Errorf("my error"))
 	child.Finish()
 
 	span.Finish()
@@ -34,7 +34,7 @@ func TestSpanWithoutParent(t *testing.T) {
 
 	child := span.NewChild("child")
 	child.SetLabel("child_key", "child_value")
-	child.SetError("error", fmt.Errorf("my error"))
+	child.SetError(fmt.Errorf("my error"))
 	child.Finish()
 
 	span.Finish()

--- a/sql.go
+++ b/sql.go
@@ -121,9 +121,7 @@ func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dri
 	span := c.GetSpan(ctx).NewChild("sql-tx-begin")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		c.Log(ctx, "sql-tx-begin", "err", err)
 	}()
@@ -149,9 +147,7 @@ func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt dri
 	span := c.GetSpan(ctx).NewChild("sql-prepare")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(ctx, c.opts, "sql-prepare", query, err, nil)
 	}()
@@ -189,9 +185,7 @@ func (c wrappedConn) ExecContext(ctx context.Context, query string, args []drive
 		span.SetLabel("args", pretty.Sprint(args))
 	}
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 
 		logQuery(ctx, c.opts, "sql-conn-exec", query, err, args)
@@ -226,9 +220,7 @@ func (c wrappedConn) Ping(ctx context.Context) (err error) {
 		span := c.GetSpan(ctx).NewChild("sql-ping")
 		span.SetLabel("component", "database/sql")
 		defer func() {
-			if err != nil {
-				span.SetError("err", err)
-			}
+			span.SetError(err)
 			span.Finish()
 			c.Log(ctx, "sql-ping", "err", err)
 		}()
@@ -262,9 +254,7 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 		span.SetLabel("args", pretty.Sprint(args))
 	}
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(ctx, c.opts, "sql-conn-query", query, err, args)
 	}()
@@ -296,9 +286,7 @@ func (t wrappedTx) Commit() (err error) {
 	span := t.GetSpan(t.ctx).NewChild("sql-tx-commit")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		t.Log(t.ctx, "sql-tx-commit", "err", err)
 	}()
@@ -310,9 +298,7 @@ func (t wrappedTx) Rollback() (err error) {
 	span := t.GetSpan(t.ctx).NewChild("sql-tx-rollback")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		t.Log(t.ctx, "sql-tx-rollback", "err", err)
 	}()
@@ -324,9 +310,7 @@ func (s wrappedStmt) Close() (err error) {
 	span := s.GetSpan(s.ctx).NewChild("sql-stmt-close")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		s.Log(s.ctx, "sql-stmt-close", "err", err)
 	}()
@@ -344,9 +328,7 @@ func (s wrappedStmt) Exec(args []driver.Value) (res driver.Result, err error) {
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(s.ctx, s.opts, "sql-stmt-exec", s.query, err, args)
 	}()
@@ -365,9 +347,7 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(s.ctx, s.opts, "sql-stmt-query", s.query, err, args)
 	}()
@@ -386,9 +366,7 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(ctx, s.opts, "sql-stmt-exec", s.query, err, args)
 	}()
@@ -423,9 +401,7 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		logQuery(ctx, s.opts, "sql-stmt-query", s.query, err, args)
 	}()
@@ -457,9 +433,7 @@ func (r wrappedResult) LastInsertId() (id int64, err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-res-lastInsertId")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		r.Log(r.ctx, "sql-res-lastInsertId", "err", err)
 	}()
@@ -471,9 +445,7 @@ func (r wrappedResult) RowsAffected() (num int64, err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-res-rowsAffected")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		r.Log(r.ctx, "sql-res-rowsAffected", "err", err)
 	}()
@@ -493,9 +465,7 @@ func (r wrappedRows) Next(dest []driver.Value) (err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-rows-next")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		if err != nil {
-			span.SetError("err", err)
-		}
+		span.SetError(err)
 		span.Finish()
 		r.Log(r.ctx, "sql-rows-next", "err", err)
 	}()

--- a/sql.go
+++ b/sql.go
@@ -3,7 +3,6 @@ package instrumentedsql
 import (
 	"context"
 	"database/sql/driver"
-	"fmt"
 
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
@@ -12,7 +11,7 @@ import (
 type opts struct {
 	Logger
 	Tracer
-	OmitArgs bool
+	OmitArgs           bool
 	TraceWithoutParent bool
 }
 
@@ -122,7 +121,9 @@ func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dri
 	span := c.GetSpan(ctx).NewChild("sql-tx-begin")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		c.Log(ctx, "sql-tx-begin", "err", err)
 	}()
@@ -148,7 +149,9 @@ func (c wrappedConn) PrepareContext(ctx context.Context, query string) (stmt dri
 	span := c.GetSpan(ctx).NewChild("sql-prepare")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(ctx, c.opts, "sql-prepare", query, err, nil)
 	}()
@@ -186,7 +189,9 @@ func (c wrappedConn) ExecContext(ctx context.Context, query string, args []drive
 		span.SetLabel("args", pretty.Sprint(args))
 	}
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 
 		logQuery(ctx, c.opts, "sql-conn-exec", query, err, args)
@@ -221,7 +226,9 @@ func (c wrappedConn) Ping(ctx context.Context) (err error) {
 		span := c.GetSpan(ctx).NewChild("sql-ping")
 		span.SetLabel("component", "database/sql")
 		defer func() {
-			span.SetLabel("err", fmt.Sprint(err))
+			if err != nil {
+				span.SetError("err", err)
+			}
 			span.Finish()
 			c.Log(ctx, "sql-ping", "err", err)
 		}()
@@ -255,7 +262,9 @@ func (c wrappedConn) QueryContext(ctx context.Context, query string, args []driv
 		span.SetLabel("args", pretty.Sprint(args))
 	}
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(ctx, c.opts, "sql-conn-query", query, err, args)
 	}()
@@ -287,7 +296,9 @@ func (t wrappedTx) Commit() (err error) {
 	span := t.GetSpan(t.ctx).NewChild("sql-tx-commit")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		t.Log(t.ctx, "sql-tx-commit", "err", err)
 	}()
@@ -299,7 +310,9 @@ func (t wrappedTx) Rollback() (err error) {
 	span := t.GetSpan(t.ctx).NewChild("sql-tx-rollback")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		t.Log(t.ctx, "sql-tx-rollback", "err", err)
 	}()
@@ -311,7 +324,9 @@ func (s wrappedStmt) Close() (err error) {
 	span := s.GetSpan(s.ctx).NewChild("sql-stmt-close")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		s.Log(s.ctx, "sql-stmt-close", "err", err)
 	}()
@@ -329,7 +344,9 @@ func (s wrappedStmt) Exec(args []driver.Value) (res driver.Result, err error) {
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(s.ctx, s.opts, "sql-stmt-exec", s.query, err, args)
 	}()
@@ -348,7 +365,9 @@ func (s wrappedStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(s.ctx, s.opts, "sql-stmt-query", s.query, err, args)
 	}()
@@ -367,7 +386,9 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(ctx, s.opts, "sql-stmt-exec", s.query, err, args)
 	}()
@@ -402,7 +423,9 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	span.SetLabel("query", s.query)
 	span.SetLabel("args", pretty.Sprint(args))
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		logQuery(ctx, s.opts, "sql-stmt-query", s.query, err, args)
 	}()
@@ -434,7 +457,9 @@ func (r wrappedResult) LastInsertId() (id int64, err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-res-lastInsertId")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		r.Log(r.ctx, "sql-res-lastInsertId", "err", err)
 	}()
@@ -446,7 +471,9 @@ func (r wrappedResult) RowsAffected() (num int64, err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-res-rowsAffected")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		r.Log(r.ctx, "sql-res-rowsAffected", "err", err)
 	}()
@@ -466,7 +493,9 @@ func (r wrappedRows) Next(dest []driver.Value) (err error) {
 	span := r.GetSpan(r.ctx).NewChild("sql-rows-next")
 	span.SetLabel("component", "database/sql")
 	defer func() {
-		span.SetLabel("err", fmt.Sprint(err))
+		if err != nil {
+			span.SetError("err", err)
+		}
 		span.Finish()
 		r.Log(r.ctx, "sql-rows-next", "err", err)
 	}()

--- a/tracer.go
+++ b/tracer.go
@@ -11,6 +11,7 @@ type Tracer interface {
 type Span interface {
 	NewChild(string) Span
 	SetLabel(k, v string)
+	SetError(k string, err error)
 	Finish()
 }
 
@@ -28,3 +29,5 @@ func (nullSpan) NewChild(string) Span {
 func (nullSpan) SetLabel(k, v string) {}
 
 func (nullSpan) Finish() {}
+
+func (nullSpan) SetError(k string, err error) {}

--- a/tracer.go
+++ b/tracer.go
@@ -11,7 +11,7 @@ type Tracer interface {
 type Span interface {
 	NewChild(string) Span
 	SetLabel(k, v string)
-	SetError(k string, err error)
+	SetError(err error)
 	Finish()
 }
 
@@ -30,4 +30,4 @@ func (nullSpan) SetLabel(k, v string) {}
 
 func (nullSpan) Finish() {}
 
-func (nullSpan) SetError(k string, err error) {}
+func (nullSpan) SetError(err error) {}

--- a/xray/tracer.go
+++ b/xray/tracer.go
@@ -1,0 +1,75 @@
+package xray
+
+import (
+	"context"
+
+	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/luna-duclos/instrumentedsql"
+)
+
+const (
+	labelError = "err"
+	labelQuery = "query"
+)
+
+type tracer struct{}
+
+type span struct {
+	ctx     context.Context
+	segment *xray.Segment
+}
+
+// NewTracer returns a tracer that will fetch spans using opentracing's SpanFromContext function
+func NewTracer() instrumentedsql.Tracer {
+	return tracer{}
+}
+
+// GetSpan returns a span
+func (tracer) GetSpan(ctx context.Context) instrumentedsql.Span {
+	seg := xray.GetSegment(ctx)
+	if seg == nil {
+		return span{ctx: nil}
+	}
+
+	return span{ctx: ctx}
+}
+
+// NewChild comply with instrumentedsql.Span
+func (s span) NewChild(name string) instrumentedsql.Span {
+	if s.ctx == nil {
+		return s
+	}
+
+	_, seg := xray.BeginSubsegment(s.ctx, name)
+	return span{ctx: s.ctx, segment: seg}
+}
+
+// SetLabel comply with instrumentedsql.Span
+func (s span) SetLabel(k, v string) {
+	if s.segment == nil {
+		return
+	}
+
+	switch k {
+	case labelQuery:
+		s.segment.GetSQL().SanitizedQuery = v
+	}
+}
+
+// SetError comply with instrumentedsql.Span
+func (s span) SetError(k string, err error) {
+	if s.segment == nil {
+		return
+	}
+
+	s.segment.AddError(err)
+}
+
+// Finish comply with instrumentedsql.Span
+func (s span) Finish() {
+	if s.segment == nil {
+		return
+	}
+
+	s.segment.Close(nil)
+}

--- a/xray/tracer.go
+++ b/xray/tracer.go
@@ -57,7 +57,11 @@ func (s span) SetLabel(k, v string) {
 }
 
 // SetError comply with instrumentedsql.Span
-func (s span) SetError(k string, err error) {
+func (s span) SetError(err error) {
+	if err == nil {
+		return
+	}
+
 	if s.segment == nil {
 		return
 	}

--- a/xray/tracer.go
+++ b/xray/tracer.go
@@ -25,6 +25,10 @@ func NewTracer() instrumentedsql.Tracer {
 
 // GetSpan returns a span
 func (tracer) GetSpan(ctx context.Context) instrumentedsql.Span {
+	if ctx == nil {
+		return span{ctx: nil}
+	}
+
 	seg := xray.GetSegment(ctx)
 	if seg == nil {
 		return span{ctx: nil}

--- a/xray/tracer.go
+++ b/xray/tracer.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	labelError = "err"
 	labelQuery = "query"
 )
 


### PR DESCRIPTION
Hello @luna-duclos 

This PR includes:

- A suggestion of supporting a `SetError` method at the span level. This is because some libraries (like the included X-Ray) needs the error object instead of a string with the error;
- Only calling the previous `SetError` if an error actually exists;
- Support for X-Ray

Let me know if this is useful/if you have any suggestions :)

/cc @melo