### PR TITLE
Fixed opencencus tracer implementation to work with current opencensus package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A sql driver that will wrap any other driver and log/trace all its calls
 
 ## How to use
 
-Please see the [documentation](https://godoc.org/github.com/ExpansiveWorlds/instrumentedsql) and [examples](https://github.com/ExpansiveWorlds/instrumentedsql/blob/master/sql_example_test.go)
+Please see the [documentation](https://godoc.org/github.com/luna-duclos/instrumentedsql) and [examples](https://github.com/luna-duclos/instrumentedsql/blob/master/sql_example_test.go)
 
 ## Roadmap
 


### PR DESCRIPTION
I attempted to use `github.com/luna-duclos/instrumentedsql/opencensus` only to find that the latest version of the [`go.opencensus.io/trace`](go.opencensus.io/trace) package has changed and `github.com/luna-duclos/instrumentedsql/opencensus` no longer compiled with it.

This fixes that.

And an issue I noticed with the links in the readme (fixes #5).