### PR TITLE
Propagate context from wrappedStmt.QueryContext to wrappedStmt.Query.

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -408,6 +408,7 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 		return nil, ctx.Err()
 	}
 
+	s.ctx = ctx
 	return s.Query(dargs)
 }
 


### PR DESCRIPTION
# Consider following scenario:

```go
db, _ := sql.Open('instrumented', dsn)
stmt, _ := db.PrepareContext(ctx, query)
rows, _ := stmt.QueryContext(ctx, args...)
for rows.Next () {
  rows.Scan(&input)
}
```

# Expected outcome:
Connected spans based on the same incoming trace
```
sql-prepare
sql-stmt-query
sql-rows-next
sql-rows-next
...
```
# Actual outcome:
Spans are being sent, but without any connection to each other - standalone traces with no parent trace.

# Why does that happen?
This, rather inconvenient, behaviour was could be observed when using https://github.com/lib/pq PostgreSQL driver.
The reason for that is that the library does implement interfaces like `driver.QueryerContext` but does NOT `driver.StmtExecContext` and `driver.ConnPrepareContext`. Due to that, 
`wrappedConn.PrepareContext` and `wrappedStmt.QueryContext` fallback to `wrappedConn.Prepare` and `wrappedStmtQuery` respectively.

While `Prepare` without context is negligible (I guess that context from Prepare should not be propagated to the statement anyway), the `wrappedStmt.Query` relies on `ctx` property which is not supplied.

# PR outcome
Context's passed to stmt.QueryContext should be re-used in stmt.Query thourgh its own copy and then passed down to `wrappedRows`.