### PR TITLE
opentracing → log error

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql/driver"
 
-	"github.com/opentracing/opentracing-go/ext"
-
 	"github.com/luna-duclos/instrumentedsql"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 type tracer struct {
@@ -61,6 +61,7 @@ func (s span) SetError(err error) {
 	}
 
 	ext.Error.Set(s.parent, true)
+	s.parent.LogFields(log.Error(err))
 }
 
 func (s span) Finish() {


### PR DESCRIPTION
After issue #7 and related pr #8 were merged error messages disappeared from traces.
In this pr errors are logged as `LogFields` according to [conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md).