### PR TITLE
fix #22 Records error but that means no more rows

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"time"
@@ -566,7 +567,9 @@ func (r wrappedRows) Next(dest []driver.Value) (err error) {
 		span := r.GetSpan(r.ctx).NewChild(OpSQLRowsNext)
 		span.SetLabel("component", "database/sql")
 		defer func() {
-			span.SetError(err)
+			if err != io.EOF {
+				span.SetError(err)
+			}
 			span.Finish()
 		}()
 	}


### PR DESCRIPTION
The method Rows.Next returns io.EOF when there are no more rows.

So we don't need mark it as an error.

ref: https://golang.org/src/database/sql/driver/driver.go?s=13916:14625#L362
