### PR TITLE
opentracing: log error messages

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -61,7 +61,10 @@ func (s span) SetError(err error) {
 	}
 
 	ext.Error.Set(s.parent, true)
-	s.parent.LogFields(log.Error(err))
+	s.parent.LogFields(
+		log.String("event", "error"),
+		log.String("message", err.Error()),
+	)
 }
 
 func (s span) Finish() {


### PR DESCRIPTION
It's useful to see when queries error out, but it would be nice to have more insight into these errors. This PR adds log fields `event="error", message="the error message"` when a span results in an error. This is the convention described in the [opentracing spec](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#captured-errors) and is the common approach to logging error messages with opentracing in Go apps.