### PR TITLE
Safely use drivers w/o DriverContext in OpenConnector.

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,97 @@
+// +build go1.10
+
+package instrumentedsql
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+)
+
+func TestConnectorWithDriverContext(t *testing.T) {
+	err := fmt.Errorf("a generic error")
+
+	tests := []struct {
+		name             string
+		openConnectorErr error
+		expectErr        bool
+	}{
+		{
+			name: "should properly open connector and wrap it",
+		},
+		{
+			name:             "should fail when calling OpenConnector",
+			openConnectorErr: err,
+			expectErr:        true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := wrappedDriver{parent: &driverContextMock{err: test.openConnectorErr}}
+			conn, err := d.OpenConnector("some-dsn")
+			if err != nil {
+				if test.expectErr {
+					return
+				}
+				t.Fatalf("unexpected error from wrapped OpenConnector impl: %+v\n", err)
+			}
+
+			wc, ok := conn.(wrappedConnector)
+			if !ok {
+				t.Fatal("expected wrapped OpenConnector to return wrappedConnetor instance")
+			}
+
+			_, ok = wc.parent.(*connMock)
+			if !ok {
+				t.Error("expected wrappedConnector to have connMock as parent")
+			}
+		})
+	}
+}
+
+func TestConnectorWithDriver(t *testing.T) {
+	d := wrappedDriver{parent: &driverMock{}}
+	conn, err := d.OpenConnector("some-dsn")
+	if err != nil {
+		t.Fatalf("unexpected error from wrapped OpenConnector impl: %+v\n", err)
+	}
+
+	wc, ok := conn.(wrappedConnector)
+	if !ok {
+		t.Fatal("expected wrapped OpenConnector to return wrappedConnetor instance")
+	}
+
+	_, ok = wc.parent.(dsnConnector)
+	if !ok {
+		t.Error("expected wrappedConnector to have dsnConnector as parent")
+	}
+}
+
+type driverMock struct{}
+
+func (d *driverMock) Open(name string) (driver.Conn, error) {
+	panic("not implemented")
+}
+
+type driverContextMock struct {
+	err error
+}
+
+func (d *driverContextMock) Open(name string) (driver.Conn, error) {
+	panic("not implemented")
+}
+
+func (d *driverContextMock) OpenConnector(name string) (driver.Connector, error) {
+	return &connMock{}, d.err
+}
+
+type connMock struct{}
+
+func (c *connMock) Connect(context.Context) (driver.Conn, error) {
+	panic("not implemented")
+}
+
+func (c *connMock) Driver() driver.Driver {
+	panic("not implemented")
+}


### PR DESCRIPTION
With #21 there's been a `panic()` call left when the given driver does not implement `DriverContext`. This leads to Go programmes not being able to connect to DB and panic if they're running Go 1.10 and a driver that does not have `DriverContext`, like [lib/pq](https://github.com/lib/pq).

This change aims to provide a fallback connector for these cases. Some tests have been added to ensure proper flow.

BTW: Frankly, I would consider `panic: go version does not support DriverContext` as a really misleading message when your app fails.