### PR TITLE
Doubled spans

### DIFF
--- a/driver_go110.go
+++ b/driver_go110.go
@@ -11,7 +11,7 @@ func (d wrappedDriver) OpenConnector(name string) (driver.Connector, error) {
 	if !ok {
 		return wrappedConnector{
 			opts:      d.opts,
-			parent:    dsnConnector{dsn: name, driver: &d},
+			parent:    dsnConnector{dsn: name, driver: d.parent},
 			driverRef: &d,
 		}, nil
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -125,7 +125,12 @@ func (s wrappedStmt) ExecContext(ctx context.Context, args []driver.NamedValue) 
 		return nil, ctx.Err()
 	}
 
-	return s.Exec(dargs)
+	res, err = s.parent.Exec(dargs)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrappedResult{opts: s.opts, ctx: ctx, parent: res}, nil
 }
 
 func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
@@ -164,8 +169,12 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 		return nil, ctx.Err()
 	}
 
-	s.ctx = ctx
-	return s.Query(dargs)
+	rows, err = s.parent.Query(dargs)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrappedRows{opts: s.opts, ctx: ctx, parent: rows}, nil
 }
 
 func (s wrappedStmt) ColumnConverter(idx int) driver.ValueConverter {


### PR DESCRIPTION
This PR addresses two causes of duplicate spans being emitted.

1. When using the dsnConnector fallback opened connections end up wrapped twice; dsnConnector replaces the parent of the driver, but the wrapped driver was being passed as its value.
2. When the underlying driver doesn't implement QueryContext and ExecContext on statements, the wrapped statement delegates to its own Query and Exec, which emit their own spans (using the context from the statement's creation).

I'm guessing this fixes #17.