### PR TITLE
Separate tracers' tests

### DIFF
--- a/google/tracer_test.go
+++ b/google/tracer_test.go
@@ -1,0 +1,19 @@
+package google_test
+
+import (
+	"database/sql"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/luna-duclos/instrumentedsql"
+	"github.com/luna-duclos/instrumentedsql/google"
+)
+
+// WrapDriverGoogle demonstrates how to call wrapDriver and register a new driver.
+// This example uses MySQL and google tracing to illustrate this
+func ExampleWrapDriver_google() {
+	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(google.NewTracer(false))))
+	db, err := sql.Open("instrumented-mysql", "connString")
+
+	// Proceed to handle connection errors and use the database as usual
+	_, _ = db, err
+}

--- a/opencensus/opencensus_test.go
+++ b/opencensus/opencensus_test.go
@@ -1,0 +1,19 @@
+package opencensus_test
+
+import (
+	"database/sql"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/luna-duclos/instrumentedsql"
+	"github.com/luna-duclos/instrumentedsql/opencensus"
+)
+
+// WrapDriverOpencensus demonstrates how to call wrapDriver and register a new driver.
+// This example uses MySQL and opencensus to illustrate this
+func ExampleWrapDriver_opencensus() {
+	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(opencensus.NewTracer(false))))
+	db, err := sql.Open("instrumented-mysql", "connString")
+
+	// Proceed to handle connection errors and use the database as usual
+	_, _ = db, err
+}

--- a/sql_example_test.go
+++ b/sql_example_test.go
@@ -5,44 +5,10 @@ import (
 	"database/sql"
 	"log"
 
-	"github.com/go-sql-driver/mysql"
-	"github.com/luna-duclos/instrumentedsql/opencensus"
 	"github.com/mattn/go-sqlite3"
 
 	"github.com/luna-duclos/instrumentedsql"
-	"github.com/luna-duclos/instrumentedsql/google"
-	"github.com/luna-duclos/instrumentedsql/opentracing"
 )
-
-// WrapDriverGoogle demonstrates how to call wrapDriver and register a new driver.
-// This example uses MySQL and google tracing to illustrate this
-func ExampleWrapDriver_google() {
-	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(google.NewTracer(false))))
-	db, err := sql.Open("instrumented-mysql", "connString")
-
-	// Proceed to handle connection errors and use the database as usual
-	_, _ = db, err
-}
-
-// WrapDriverOpentracing demonstrates how to call wrapDriver and register a new driver.
-// This example uses MySQL and opentracing to illustrate this
-func ExampleWrapDriver_opentracing() {
-	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(opentracing.NewTracer(false))))
-	db, err := sql.Open("instrumented-mysql", "connString")
-
-	// Proceed to handle connection errors and use the database as usual
-	_, _ = db, err
-}
-
-// WrapDriverOpencensus demonstrates how to call wrapDriver and register a new driver.
-// This example uses MySQL and opencensus to illustrate this
-func ExampleWrapDriver_opencensus() {
-	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(opencensus.NewTracer(false))))
-	db, err := sql.Open("instrumented-mysql", "connString")
-
-	// Proceed to handle connection errors and use the database as usual
-	_, _ = db, err
-}
 
 // WrapDriverJustLogging demonstrates how to call wrapDriver and register a new driver.
 // This example uses sqlite, and does not trace, but merely logs all calls


### PR DESCRIPTION
I'm using your library in one of my projects, and since cloud.google.com/go/trace no longer exists (#29), it causes some problems or us even though we don't use Google's tracing and want to use newer version of that Google's dependency. The test in the main package do rely on all three tracers' packages (which BTW is not ideal), and my PR solves this.

I moved the "example SQL test" cases to their respective packages, and since I noticed that you are using a `package package_test` convention, I did that too. This forced me to make a tiny change in one of the existing tests, but I wanted to follow the convention.