### PR TITLE
Export the WrappedDriver type

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -11,7 +11,7 @@ import (
 type wrappedConnector struct {
 	opts
 	parent    driver.Connector
-	driverRef *wrappedDriver
+	driverRef *WrappedDriver
 }
 
 var (

--- a/connector_test.go
+++ b/connector_test.go
@@ -28,7 +28,7 @@ func TestConnectorWithDriverContext(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			d := wrappedDriver{parent: &driverContextMock{err: test.openConnectorErr}}
+			d := WrappedDriver{parent: &driverContextMock{err: test.openConnectorErr}}
 			conn, err := d.OpenConnector("some-dsn")
 			if err != nil {
 				if test.expectErr {
@@ -51,7 +51,7 @@ func TestConnectorWithDriverContext(t *testing.T) {
 }
 
 func TestConnectorWithDriver(t *testing.T) {
-	d := wrappedDriver{parent: &driverMock{}}
+	d := WrappedDriver{parent: &driverMock{}}
 	conn, err := d.OpenConnector("some-dsn")
 	if err != nil {
 		t.Fatalf("unexpected error from wrapped OpenConnector impl: %+v\n", err)

--- a/driver.go
+++ b/driver.go
@@ -2,14 +2,16 @@ package instrumentedsql
 
 import "database/sql/driver"
 
-type wrappedDriver struct {
+// WrappedDriver wraps a driver and adds instrumentation.
+// Use WrapDriver to create a new WrappedDriver.
+type WrappedDriver struct {
 	opts
 	parent driver.Driver
 }
 
 // Compile time validation that our types implement the expected interfaces
 var (
-	_ driver.Driver = wrappedDriver{}
+	_ driver.Driver = WrappedDriver{}
 )
 
 // WrapDriver will wrap the passed SQL driver and return a new sql driver that uses it and also logs and traces calls using the passed logger and tracer
@@ -18,8 +20,8 @@ var (
 // Important note: Seeing as the context passed into the various instrumentation calls this package calls,
 // Any call without a context passed will not be instrumented. Please be sure to use the ___Context() and BeginTx() function calls added in Go 1.8
 // instead of the older calls which do not accept a context.
-func WrapDriver(driver driver.Driver, opts ...Opt) driver.Driver {
-	d := wrappedDriver{parent: driver}
+func WrapDriver(driver driver.Driver, opts ...Opt) WrappedDriver {
+	d := WrappedDriver{parent: driver}
 
 	for _, opt := range opts {
 		opt(&d.opts)
@@ -35,7 +37,8 @@ func WrapDriver(driver driver.Driver, opts ...Opt) driver.Driver {
 	return d
 }
 
-func (d wrappedDriver) Open(name string) (driver.Conn, error) {
+// Open implements the database/sql/driver.Driver interface for WrappedDriver.
+func (d WrappedDriver) Open(name string) (driver.Conn, error) {
 	conn, err := d.parent.Open(name)
 	if err != nil {
 		return nil, err

--- a/driver_go110.go
+++ b/driver_go110.go
@@ -4,9 +4,9 @@ package instrumentedsql
 
 import "database/sql/driver"
 
-var _ driver.DriverContext = wrappedDriver{}
+var _ driver.DriverContext = WrappedDriver{}
 
-func (d wrappedDriver) OpenConnector(name string) (driver.Connector, error) {
+func (d WrappedDriver) OpenConnector(name string) (driver.Connector, error) {
 	driver, ok := d.parent.(driver.DriverContext)
 	if !ok {
 		return wrappedConnector{


### PR DESCRIPTION
This makes it easier to use the other
methods exposed on the wrapped driver.