### PR TITLE
Use parent tracer when creating an opentracing span

### DIFF
--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -41,7 +41,7 @@ func (s span) NewChild(name string) instrumentedsql.Span {
 		return s
 	}
 
-	return span{parent: opentracing.StartSpan(name, opentracing.ChildOf(s.parent.Context())), tracer: s.tracer}
+	return span{parent: s.parent.Tracer().StartSpan(name, opentracing.ChildOf(s.parent.Context())), tracer: s.tracer}
 }
 
 func (s span) SetLabel(k, v string) {


### PR DESCRIPTION
All opentracing spans expose a method that returns the tracer that created it, using it when creating child of one opentracing span makes more sense than using the global one.

Note: In our setup using the global tracer is an issue because we have 2 different tracers creating spans: a real one and a noop tracer in some cases.