### PR TITLE
Fixes issue #41 (NumInput() returns -1 with NamedValueChecker)

### DIFF
--- a/LICENSE.golang
+++ b/LICENSE.golang
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/stmt.go
+++ b/stmt.go
@@ -15,10 +15,9 @@ type wrappedStmt struct {
 
 // Compile time validation that our types implement the expected interfaces
 var (
-	_ driver.Stmt = wrappedStmt{}
-	_ driver.StmtExecContext = wrappedStmt{}
+	_ driver.Stmt             = wrappedStmt{}
+	_ driver.StmtExecContext  = wrappedStmt{}
 	_ driver.StmtQueryContext = wrappedStmt{}
-	_ driver.ColumnConverter = wrappedStmt{}
 )
 
 func (s wrappedStmt) Close() (err error) {
@@ -175,12 +174,4 @@ func (s wrappedStmt) QueryContext(ctx context.Context, args []driver.NamedValue)
 	}
 
 	return wrappedRows{opts: s.opts, ctx: ctx, parent: rows}, nil
-}
-
-func (s wrappedStmt) ColumnConverter(idx int) driver.ValueConverter {
-	if converter, ok := s.parent.(driver.ColumnConverter); ok {
-		return converter.ColumnConverter(idx)
-	}
-
-	return driver.DefaultParameterConverter
 }

--- a/stmt_go18.go
+++ b/stmt_go18.go
@@ -1,0 +1,15 @@
+// +build !go1.9
+
+package instrumentedsql
+
+import "database/sql/driver"
+
+var _ driver.ColumnConverter = wrappedStmt{}
+
+func (s wrappedStmt) ColumnConverter(idx int) driver.ValueConverter {
+	if converter, ok := s.parent.(driver.ColumnConverter); ok {
+		return converter.ColumnConverter(idx)
+	}
+
+	return driver.DefaultParameterConverter
+}

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -1,3 +1,7 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.golang file.
+
 // +build go1.9
 
 package instrumentedsql

--- a/stmt_go19.go
+++ b/stmt_go19.go
@@ -1,13 +1,105 @@
+// +build go1.9
+
 package instrumentedsql
 
-import "database/sql/driver"
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+)
 
 var _ driver.NamedValueChecker = wrappedStmt{}
 
-func (c wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
-	if checker, ok := c.parent.(driver.NamedValueChecker); ok {
-		return checker.CheckNamedValue(v)
+func (s wrappedStmt) CheckNamedValue(v *driver.NamedValue) error {
+	if checker, ok := s.parent.(driver.NamedValueChecker); ok {
+		err := checker.CheckNamedValue(v)
+		if err != driver.ErrSkip {
+			return err
+		}
+	}
+
+	if converter, ok := s.parent.(driver.ColumnConverter); ok {
+		cc := ccChecker{
+			cci:  converter,
+			want: s.NumInput(),
+		}
+		return cc.CheckNamedValue(v)
 	}
 
 	return driver.ErrSkip
+}
+
+// ccChecker wraps the driver.ColumnConverter and allows it to be used
+// as if it were a NamedValueChecker. If the driver ColumnConverter
+// is not present then the NamedValueChecker will return driver.ErrSkip.
+type ccChecker struct {
+	cci  driver.ColumnConverter
+	want int
+}
+
+func (c ccChecker) CheckNamedValue(nv *driver.NamedValue) error {
+	if c.cci == nil {
+		return driver.ErrSkip
+	}
+	// The column converter shouldn't be called on any index
+	// it isn't expecting. The final error will be thrown
+	// in the argument converter loop.
+	index := nv.Ordinal - 1
+	if c.want <= index {
+		return nil
+	}
+
+	// First, see if the value itself knows how to convert
+	// itself to a driver type. For example, a NullString
+	// struct changing into a string or nil.
+	if vr, ok := nv.Value.(driver.Valuer); ok {
+		sv, err := callValuerValue(vr)
+		if err != nil {
+			return err
+		}
+		if !driver.IsValue(sv) {
+			return fmt.Errorf("non-subset type %T returned from Value", sv)
+		}
+		nv.Value = sv
+	}
+
+	// Second, ask the column to sanity check itself. For
+	// example, drivers might use this to make sure that
+	// an int64 values being inserted into a 16-bit
+	// integer field is in range (before getting
+	// truncated), or that a nil can't go into a NOT NULL
+	// column before going across the network to get the
+	// same error.
+	var err error
+	arg := nv.Value
+	nv.Value, err = c.cci.ColumnConverter(index).ConvertValue(arg)
+	if err != nil {
+		return err
+	}
+	if !driver.IsValue(nv.Value) {
+		return fmt.Errorf("driver ColumnConverter error converted %T to unsupported type %T", arg, nv.Value)
+	}
+	return nil
+}
+
+var valuerReflectType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
+
+// callValuerValue returns vr.Value(), with one exception:
+// If vr.Value is an auto-generated method on a pointer type and the
+// pointer is nil, it would panic at runtime in the panicwrap
+// method. Treat it like nil instead.
+// Issue 8415.
+//
+// This is so people can implement driver.Value on value types and
+// still use nil pointers to those types to mean nil/NULL, just like
+// string/*string.
+//
+// This function is mirrored in the database/sql/driver package.
+func callValuerValue(vr driver.Valuer) (v driver.Value, err error) {
+	if rv := reflect.ValueOf(vr); rv.Kind() == reflect.Ptr &&
+		rv.IsNil() &&
+		rv.Type().Elem().Implements(valuerReflectType) {
+		return nil, nil
+	}
+	return vr.Value()
 }


### PR DESCRIPTION
Do not implement driver.ColumnConverter on go1.9+ as the act of implementing this interface causes a side effect with a compatibility wrapper.
Instead only implement the replacement driver.NamedValueChecker interface on go1.19+ and handle compatibility with drivers implementing driver.ColumnConverter ourselves to avoid the unintentional side effects from happening when driver.ColumnConverter is not implemented by the underlying driver.

As an aside, I noticed a number of files are missing their trailing new lines and do not follow go fmt formatting. I've only run go fmt on files I edited to avoid unnecessary conflicts, but this should probably be run across the whole repo.