### PR TITLE
do not pass a nil Context to logger.Log()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,7 +29,7 @@ func (c wrappedConn) Prepare(query string) (driver.Stmt, error) {
 		return nil, err
 	}
 
-	return wrappedStmt{opts: c.opts, query: query, parent: parent}, nil
+	return wrappedStmt{opts: c.opts, ctx: context.TODO(), query: query, parent: parent}, nil
 }
 
 func (c wrappedConn) Close() error {
@@ -42,7 +42,7 @@ func (c wrappedConn) Begin() (driver.Tx, error) {
 		return nil, err
 	}
 
-	return wrappedTx{opts: c.opts, parent: tx}, nil
+	return wrappedTx{opts: c.opts, ctx: context.TODO(), parent: tx}, nil
 }
 
 func (c wrappedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {


### PR DESCRIPTION
wrappedStmt and wrappedTx was uninitialized with a nil context in
Prepare() and Close().
This caused that in some cases logger.Log() was called with a nil ctx,
the nil ctx could then get forwarded to an external logger
implementation.
Passing a nil context causes a panic in some logger implementations.

A nil context should never be passed, as stated by the context package
documentation:

> Do not pass a nil Context, even if a function permits it. Pass
> context.TODO if you are unsure about which Context to use.
https://pkg.go.dev/context#pkg-overview

Initialize ctx with context.TODO() instead of nil, if no other ctx is
available.