### PR TITLE
Add support for DataDog

### DIFF
--- a/datadog/go.mod
+++ b/datadog/go.mod
@@ -1,0 +1,9 @@
+module datadog
+
+go 1.14
+
+require (
+	github.com/go-sql-driver/mysql v1.6.0
+	github.com/luna-duclos/instrumentedsql v1.1.3
+	gopkg.in/DataDog/dd-trace-go.v1 v1.33.0
+)

--- a/datadog/tracer.go
+++ b/datadog/tracer.go
@@ -1,0 +1,89 @@
+package datadog
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"github.com/luna-duclos/instrumentedsql"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+type trace struct {
+	traceOrphans bool
+}
+
+type span struct {
+	trace
+	ctx    context.Context
+	parent ddtrace.Span
+}
+
+type TraceOption func(t *trace)
+
+// NewTracer returns a tracer which will fetch spans using datadog's SpanFromContext function.
+func NewTracer(opts ...TraceOption) instrumentedsql.Tracer {
+	t := &trace{
+		traceOrphans: false,
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// TraceOrphans will create spans with no parent if true, otherwise only spans with parents will be generated.
+// Defaults to false, useful for preventing excessive tracing.
+func TraceOrphans(traceOrphans bool) TraceOption {
+	return func(t *trace) {
+		t.traceOrphans = traceOrphans
+	}
+}
+
+// GetSpan returns a span.
+func (t trace) GetSpan(ctx context.Context) instrumentedsql.Span {
+	ddSpan, ok := tracer.SpanFromContext(ctx)
+	if !ok {
+		return span{parent: nil, ctx: ctx, trace: t}
+	}
+	return span{parent: ddSpan, ctx: ctx, trace: t}
+}
+
+// NewChild starts a child span.
+func (s span) NewChild(name string) instrumentedsql.Span {
+	if s.parent == nil && !s.traceOrphans {
+		return s
+	}
+	opts := []ddtrace.StartSpanOption{
+		tracer.SpanType(ext.SpanTypeSQL),
+		tracer.Measured(),
+	}
+	newSpan, ctx := tracer.StartSpanFromContext(s.ctx, name, opts...)
+	return span{parent: newSpan, ctx: ctx, trace: s.trace}
+}
+
+// SetLabel sets a tag on the span.
+func (s span) SetLabel(k, v string) {
+	if s.parent == nil {
+		return
+	}
+	s.parent.SetTag(k, v)
+}
+
+// SetError sets a tag with the error.
+func (s span) SetError(err error) {
+	if err == nil || err == driver.ErrSkip || s.parent == nil {
+		return
+	}
+	s.parent.SetTag("err", err.Error())
+}
+
+// Finish finishes the span.
+func (s span) Finish() {
+	if s.parent == nil {
+		return
+	}
+	s.parent.Finish()
+}

--- a/datadog/tracer_test.go
+++ b/datadog/tracer_test.go
@@ -1,0 +1,18 @@
+package datadog
+
+import (
+	"database/sql"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/luna-duclos/instrumentedsql"
+)
+
+// WrapDriverDatadog demonstrates how to call wrapDriver and register a new driver.
+// This example uses MySQL and datadog to illustrate this
+func ExampleWrapDriver_datadog() {
+	sql.Register("instrumented-mysql", instrumentedsql.WrapDriver(mysql.MySQLDriver{}, instrumentedsql.WithTracer(NewTracer())))
+	db, err := sql.Open("instrumented-mysql", "connString")
+
+	// Proceed to handle connection errors and use the database as usual
+	_, _ = db, err
+}


### PR DESCRIPTION
This PR adds a tracer implementation for DataDog.  We've been using this successfully for several month, and would like to share it with the community.  Please note I've been required by my employer to include the below text in the PR :).

---
The contribution was created in whole or in part by me during the course of my work at Secureworks, Inc., and I have the right and approval to submit it under the open source license indicated by the project maintainers. I understand and agree that this project and the contribution are public and that a record of the contribution is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved. If accepted, this contribution becomes owned by the project under control of the project maintainers.