### PR TITLE
Fix typo in docs

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,7 +2,7 @@ package instrumentedsql
 
 import "context"
 
-// Logger is the interface needed to be implemented by any logging implementation we use, see also NewFuncLogger
+// Logger is the interface needed to be implemented by any logging implementation we use, see also FuncLogger.
 type Logger interface {
 	Log(ctx context.Context, msg string, keyvals ...interface{})
 }


### PR DESCRIPTION
Thanks for this cool project! I haven't used it yet, but I found this typo when I was scrolling through the code base.

Refactoring commit 71b43c0b3e0ac7c08a255c5a46761072b9d6e2a3 missed to update this.